### PR TITLE
Improve mechanism that picks the closest color

### DIFF
--- a/src/Legofy.php
+++ b/src/Legofy.php
@@ -12,6 +12,10 @@ class Legofy
 {
     private $brick;
     private $brickAverageColor;
+
+    /**
+     * @var LegoPaletteInterface
+     */
     private $palette;
 
     public function __construct($brickResource = null, LegoPaletteInterface $palette = null)

--- a/src/Pallete/ColorPalette.php
+++ b/src/Pallete/ColorPalette.php
@@ -6,7 +6,7 @@ use Intervention\Image\AbstractColor;
 
 class ColorPalette implements LegoPaletteInterface
 {
-    private $palette = [
+    private const PALETTE = [
         '024' => [
             254,
             196,
@@ -264,28 +264,31 @@ class ColorPalette implements LegoPaletteInterface
         ],
     ];
 
+    /**
+     * @link https://stackoverflow.com/questions/4485229/rgb-to-closest-predefined-color
+     */
     public function pickClosestColor(AbstractColor $color): AbstractColor
     {
         $distances = [];
 
         $colorArray = $color->getArray();
 
-        foreach ($this->palette as $colorIdentifier => $colorSchema) {
-            $distance =
-                abs($colorSchema[0] - $colorArray[0]) +
-                abs($colorSchema[1] - $colorArray[1]) +
-                abs($colorSchema[2] - $colorArray[2]);
+        foreach (self::PALETTE as $colorIdentifier => $colorSchema) {
 
-            $distances[$distance] = [$colorSchema[0], $colorSchema[1], $colorSchema[2]];
+            $rDistance = $colorSchema[0] - $colorArray[0];
+            $gDistance = $colorSchema[1] - $colorArray[1];
+            $bDistance = $colorSchema[2] - $colorArray[2];
+
+            $distance = ($rDistance * .299) ** 2 + ($gDistance * .587) ** 2 + ($bDistance * .114) ** 2;
+
+            $distances[$colorIdentifier] = $distance;
         }
 
-        ksort($distances);
+        asort($distances);
 
-        $colorFound = reset($distances);
+        $colorIdentifier = array_keys($distances)[0];
 
-        list($r, $g, $b) = $colorFound;
-
-        $color->initFromRgb($r, $g, $b);
+        $color->initFromRgb(...self::PALETTE[$colorIdentifier]);
 
         return $color;
     }

--- a/src/Pallete/ColorPalette.php
+++ b/src/Pallete/ColorPalette.php
@@ -274,7 +274,6 @@ class ColorPalette implements LegoPaletteInterface
         $colorArray = $color->getArray();
 
         foreach (self::PALETTE as $colorIdentifier => $colorSchema) {
-
             $rDistance = $colorSchema[0] - $colorArray[0];
             $gDistance = $colorSchema[1] - $colorArray[1];
             $bDistance = $colorSchema[2] - $colorArray[2];


### PR DESCRIPTION
The mechanism that picked the closest color was pretty naive. It took the sum of the R, G and B distances separately.

This mechanism takes into consideration that the three colors are in are 3-D space and weights R, G and B differently. I took it from Stack Overflow.

Using this source image:
![source](https://user-images.githubusercontent.com/701299/46376495-68c5fd00-c696-11e8-83d3-46e23c6c7ca1.jpg)

The naive algorithm would generate this image:

![lego-default](https://user-images.githubusercontent.com/701299/46376494-68c5fd00-c696-11e8-8cf7-15fcd8210157.jpg)

The improved algorithm generates this image:

![lego-closest](https://user-images.githubusercontent.com/701299/46376493-68c5fd00-c696-11e8-968e-4b85eafd4f91.jpg)

Note that it is less noisy.
