### PR TITLE
Remove inclusion of Imgur and Dotenv

### DIFF
--- a/tests/Integration/MainIntegrationTest.php
+++ b/tests/Integration/MainIntegrationTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\RicardoFiorani\Integration;
 
-use Dotenv\Dotenv;
-use Imgur\Client;
 use Intervention\Image\Image;
 use PHPUnit\Framework\TestCase;
 use RicardoFiorani\Legofy\Legofy;


### PR DESCRIPTION
Looks like the usages of Imgur and Dotenv were removed in a950a7b.